### PR TITLE
Prioritize iata match over name substring match in searchByAirportName

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 var airports = require('./airports')
 var _ = require('lodash');
+var Autocomplete = require('triecomplete');
+
+var airportIataAutocomplete = new Autocomplete();
+airportIataAutocomplete.initialize(_.map(airports, function(a) {
+  return [a.iata.toLowerCase(), a];
+}));
 
 airports = _.indexBy(airports, function(a) {
   return a.iata;
@@ -10,9 +16,32 @@ module.exports.lookupByIataCode = function(iataCode) {
 }
 
 module.exports.searchByAirportName = function(name) {
-  return _.chain(airports)
+  if (_.isEmpty(name)) {
+    return [];
+  }
+
+  name = name.toLowerCase();
+
+  var iataResults = [];
+  var nameResults = [];
+
+  if (name.length <= 3) {
+    // searches airport by iata, using name as prefix
+    iataResults = _.chain(airportIataAutocomplete.search(name))
+      .pluck('value')
+      .sortBy('iata')
+      .value();
+  }
+
+  var iatas = _.pluck(iataResults, 'iata');
+
+  nameResults = _.chain(airports)
     .filter(function(v) {
-      return v.name.toLowerCase().indexOf(name.toLowerCase()) > -1
+      return !_.contains(iatas, v.iata) && v.name.toLowerCase().indexOf(name) > -1
     })
     .value()
+
+  // have airports with matching iatas be listed before airports with names that
+  // have a matching substring
+  return iataResults.concat(nameResults);
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "chai": "^3.0.0",
     "csvtojson": "^0.3.21",
     "mocha": "^2.2.5",
-    "request": "^2.58.0"
+    "request": "^2.58.0",
+    "triecomplete": "0.0.1"
   },
   "dependencies": {
     "lodash": "^3.9.3"

--- a/test/all.js
+++ b/test/all.js
@@ -20,6 +20,12 @@ describe('all', function() {
   it('should search up an airport by name', function() {
     var rows = index.searchByAirportName('newark')
     expect(_.pluck(rows, "iata")).to.contain("EWR")
-  })
+  });
 
+  it('should match iata before name', function() {
+    var rows = index.searchByAirportName('sfo');
+    expect(rows).to.have.length.above(0);
+    var row = rows[0];
+    expect(row.iata).to.equal('SFO');
+  });
 })


### PR DESCRIPTION
I was using airports.searchByAirportName to autocomplete on 'SFO' and noticed Abbot[sfo]rd was coming up first, so I thought listing iata matches first might be more useful. 

It's searchByAirportName so I could see it being unexpected that iata prefix matches are listed first. I'm wondering if its better to just move it to a general search method that tries to be a little smarter, and keep searchByAirportName as is, though not sure how much use searchByAirportName would offer separately. A separate search would probably be iata prefixes and name substrings, since it seems to me name prefixes aren't as useful.